### PR TITLE
Fix nmb-maven-plugin docs url

### DIFF
--- a/netbeans.apache.org/src/content/wiki/DevFaqMavenHowToMigrateFromANT.asciidoc
+++ b/netbeans.apache.org/src/content/wiki/DevFaqMavenHowToMigrateFromANT.asciidoc
@@ -106,7 +106,7 @@ for
  </test-dependencies>
 ----
 
-There is still more to do. Like to configure export packages, signing, homepage and so one. Most of these configuration settings defined in the original project.properties have a counterpart in the plugin configuration of the nbm-maven-plugin. See the detailed goal documentation at link:http://mojo.codehaus.org/nbm-maven/nbm-maven-plugin/nbm-mojo.html[http://mojo.codehaus.org/nbm-maven/nbm-maven-plugin/nbm-mojo.html]
+There is still more to do. Like to configure export packages, signing, homepage and so one. Most of these configuration settings defined in the original project.properties have a counterpart in the plugin configuration of the nbm-maven-plugin. See the detailed goal documentation at link:http://www.mojohaus.org/nbm-maven-plugin/[http://www.mojohaus.org/nbm-maven-plugin/]
 
 Copied from link:http://benkiew.wordpress.com/2013/10/21/how-convert-an-ant-based-netbeans-module-to-a-maven-based-netbeans-module/[http://benkiew.wordpress.com/2013/10/21/how-convert-an-ant-based-netbeans-module-to-a-maven-based-netbeans-module/]. Tested with NB7.4
 


### PR DESCRIPTION
Codehaus has been shutdown, so this pull requests changes the documentation link to the correct url.